### PR TITLE
Add default latency setting and experiment URL parameters

### DIFF
--- a/js/fps.js
+++ b/js/fps.js
@@ -86,8 +86,11 @@ var nextState = function(){
     // Set reasonable start latency
     var avgFrameTime = frameTimes.avg();
     console.log('Average frame time of ' + avgFrameTime + ' ms')
-    const INITIAL_LATENCY_FRAMES = Math.round(INITIAL_LATENCY_MS / frameTimes.avg());
-    latencySlider.value = INITIAL_LATENCY_FRAMES
+
+    var delay_frames 
+    if (INITIAL_LATENCY_FRAMES > 0) delay_frames = INITIAL_LATENCY_FRAMES;
+    else delay_frames = Math.round(INITIAL_LATENCY_MS / frameTimes.avg());
+    latencySlider.value = delay_frames
     latencySlider.oninput()
     // set_latency(latencySlider.min); // Set the minimum latency
   }
@@ -355,6 +358,7 @@ const RANDOM_ORDER = getURLParamIfPresent('randomizeOrder', false);   // Apply r
 const MEAS_DUR_S = getURLParamIfPresent('measurementDuration' , 60);  // Time to measure for each latency condition
 const MIN_FRAME_RATE = getURLParamIfPresent('warnFrameRate', 30); // Below this frame rate a warning is displayed
 const INITIAL_LATENCY_MS = getURLParamIfPresent('defaultLatencyMs', 66); // This is the initial target latency
+const INITIAL_LATENCY_FRAMES = getURLParamIfPresent('defaultLatencyFrames', -1); // This is the target latency in frames (unused if -1)
 
 function exportConfig(){
   var a = document.createElement('a');

--- a/js/fps.js
+++ b/js/fps.js
@@ -25,14 +25,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 "use strict"                      // Execute this code in "strict mode"
 
 // Experiment parameters
-const MEAS_DUR_S = 60;
 const TARGET_SIZE = 0.6;
 const TARGET_DIST = 30;
 const TARGET_HEIGHT = 6;
 const TARGET_CROUCH_HEIGHT = 4;
 const TARGET_JUMP = true;
 const TARGET_CROUCH = true;
-const MIN_FRAME_RATE = 30; // Below this frame rate a warning is displayed
 
 // States that the experiment progresses through
 const states = ["sensitivity", "latency", "measurement", "sandbox"]
@@ -85,11 +83,13 @@ var nextState = function(){
   else if(state == "latency") { // Moving into latency adjustment state
     sensitivityDiv.style.visibility = 'hidden';
     latencyDiv.style.visibility = 'visible';
-    // Predict 60ms of latency
-    // var start_lat = Math.round(60 / frameTimes.avg());
-    // latencySlider.value = start_lat
-    // latencySlider.oninput()
-    set_latency(latencySlider.min); // Set the minimum latency
+    // Set reasonable start latency
+    var avgFrameTime = frameTimes.avg();
+    console.log('Average frame time of ' + avgFrameTime + ' ms')
+    const INITIAL_LATENCY_FRAMES = Math.round(INITIAL_LATENCY_MS / frameTimes.avg());
+    latencySlider.value = INITIAL_LATENCY_FRAMES
+    latencySlider.oninput()
+    // set_latency(latencySlider.min); // Set the minimum latency
   }
   else if(state == "measurement") {
     // Build up our latency conditions based on the JND latency here
@@ -350,8 +350,11 @@ var config = {
   }
 };
 
-const RANDOM_ORDER = getURLParamIfPresent('randomizeOrder', false); // Apply random order to conditions
-
+// URL provided constant parameters
+const RANDOM_ORDER = getURLParamIfPresent('randomizeOrder', false);   // Apply random order to conditions
+const MEAS_DUR_S = getURLParamIfPresent('measurementDuration' , 60);  // Time to measure for each latency condition
+const MIN_FRAME_RATE = getURLParamIfPresent('warnFrameRate', 30); // Below this frame rate a warning is displayed
+const INITIAL_LATENCY_MS = getURLParamIfPresent('defaultLatencyMs', 66); // This is the initial target latency
 
 function exportConfig(){
   var a = document.createElement('a');

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@ Typically JSON parameter names are _very_ similar to URL parameter names, but of
     * The time (in seconds) to measure for each experiment: `measurementDuration` (`Number`) = `60`
     * The frame rate at which to warn user for perf: `warnFrameRate` (`Number`) = `30`
     * The initial JND latency target in milliseconds (may not be accurate!): `defaultLatencyMs` (`Number`) = `66`
+    * The initial JND latency target in frames (accurate, but deprioritized/scales w/ frame rate): `defaultLatencyFrames` (`Integer`) = `-1`
 
 * Rendering
     * Set frame rate?: `setFPS` (`Boolean`) = `False`

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,12 @@ Currently supported configuration is provided as a nested list below. The format
 
 Typically JSON parameter names are _very_ similar to URL parameter names, but often with less verbosity as they are inherently nested in the configuration dictionary.
 
+* Experiment
+    * Randomize latency condition order? : `randomizeOrder` (`Boolean`) = `False`
+    * The time (in seconds) to measure for each experiment: `measurementDuration` (`Number`) = `60`
+    * The frame rate at which to warn user for perf: `warnFrameRate` (`Number`) = `30`
+    * The initial JND latency target in milliseconds (may not be accurate!): `defaultLatencyMs` (`Number`) = `66`
+
 * Rendering
     * Set frame rate?: `setFPS` (`Boolean`) = `False`
     * Frame rate: `frameRate` (`Number`) = `60`


### PR DESCRIPTION
This branch adds an initial target of 66ms of added latency for the JND condition. This is based (roughly) on results from internal piloting of the experiment. This number can be adjusted in code or provided as a URL param (see below).

This branch also adds support for setting some additional experiment parameters via URL parameters, namely:

- `measurementDuration` the duration (in seconds) to run each measurement phase for (3x measurement phases)
- `warnFrameRate` the frame rate (in fps) at which to display the performance monitor in red
- `defaultLatencyMs` the default latency (in milliseconds) to attempt to provide for the latency adjustment phase

