### PR TITLE
Add fixed conditions URL parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,10 +455,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.-->
         <div id='highdiffresult'></div>
         <div id='resultsActions'>
             <button onclick="copyTableTSV(true)">Copy Table</button>
-            <button onclick="copyTableTSV(false)">Copy Row</button>
+            <button id="copyRowBtn" onclick="copyTableTSV(false)">Copy Row</button>
             <button onclick="downloadTableAsCSV(true)">Full CSV</button>
-            <button onclick="downloadTableAsCSV(false)">CSV Row</button>
-            <button id="toggleResultsVis" onclick="toggleResultsVisible()">Show Table</button>
+            <button id="dlRowBtn" onclick="downloadTableAsCSV(false)">CSV Row</button>
+            <button id="toggleResultsVis" onclick="toggleResultsTableVisible()">Show Table</button>
             <br>
             <table id="results_table">
                 <thead>

--- a/js/fps.js
+++ b/js/fps.js
@@ -474,7 +474,7 @@ if (FRAME_DELAYS_STR.length > 0) {
   const fd_fields = FRAME_DELAYS_STR.split(',')
   // Parse integer frame delays from CSV string
   for(var i = 0; i < fd_fields.length; i++) {
-    fixedFrameDelays.push(parseInt(fd_fields[i].trim()));
+    fixedFrameDelays.push(parseInt(fd_fields[i].trim().replace(/['"]+/g, '')));
   }
 }
 sensitivitySlider.value = config.player.mouseSensitivity; // Initialize sensitivity slider from player mouse sensitivity

--- a/js/fps.js
+++ b/js/fps.js
@@ -87,6 +87,7 @@ var nextState = function(){
     }
   }
   if(state == "latency") { // Moving into latency adjustment state
+    console.log(`Using a sensitivity value of ${config.player.mouseSensitivity}`)
     if(useFixedFrameDelays) { // Use fixed delays, skip this state
       state = 'measurement';
       stateIdx += 1;

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@ Typically JSON parameter names are _very_ similar to URL parameter names, but of
     * The frame rate at which to warn user for perf: `warnFrameRate` (`Number`) = `30`
     * The initial JND latency target in milliseconds (may not be accurate!): `defaultLatencyMs` (`Number`) = `66`
     * The initial JND latency target in frames (accurate, but deprioritized/scales w/ frame rate): `defaultLatencyFrames` (`Integer`) = `-1`
+    * Constant frame delays to test (skips latency and sensitivity adjustment): `frameDelays` (`CSV String`) = `''` (example usage: `frameDelays = 0,3,5,10`)
 
 * Rendering
     * Set frame rate?: `setFPS` (`Boolean`) = `False`


### PR DESCRIPTION
This branch adds a `frameDelays` URL parameter that allows a user to specify an exact set of conditions to be tested. When provided the experiment provides neither sensitivity adjustment nor JND latency adjustment conditions and instead relies on the `frameDelays` URL param for conditions and optionally providing the `mouseSensitivity` parameter to set a different mouse sensitivity.

When constant `frameDelays` are provided the results are displayed only as a table w/ the usual button options, but no colored results summary is provided.

This branch also fixes a minor bug in which reference target hit time was being counted towards time on target. 

#9 should be merged before this branch.