### PR TITLE
Disable particles, use target color for tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -542,10 +542,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.-->
         <div>
             <h1 classname="element" id="measHeader">Measurement Phase 1/3</h1>
             <p>
-                Try to track the green target as well as possible after clicking on the yellow one <br>
+                Try to track the moving target as well as possible<br>
                 Destroy (click) the yellow target to begin<br>
                 <br>
-                <i>You don't have to hold down/click the mouse button for the green target</i><br>
+                <i>You don't have to hold down the mouse button after clicking</i><br>
                 <br>
             </p>
             <table class="controls_table">

--- a/index.html
+++ b/index.html
@@ -545,7 +545,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.-->
                 Try to track the moving target as well as possible<br>
                 Destroy (click) the yellow target to begin<br>
                 <br>
-                <i>You don't have to hold down the mouse button after clicking</i><br>
+                <i>You don't have to hold down the mouse button while tracking</i><br>
                 <br>
             </p>
             <table class="controls_table">

--- a/js/fps.js
+++ b/js/fps.js
@@ -449,7 +449,7 @@ var config = {
     maxJumpCrouchTime : getURLParamIfPresent('targetMaxJumpCrouchTime', 2),
 
     reference : { // Reference target configuration
-      color: getURLParamIfPresent('refTargetColor', '#ffff00'),      // Color for the reference target
+      color: getURLParamIfPresent('refTargetColor', '#fac200'),      // Color for the reference target
       size: getURLParamIfPresent('refTargetSize', 1),             // Reference target size
       distance: getURLParamIfPresent('refTargetDistance', 30),    // Reference target distance
     },

--- a/js/fps.js
+++ b/js/fps.js
@@ -424,8 +424,8 @@ var config = {
     maxSpeed : getURLParamIfPresent('targetMaxSpeed', 12),                  // Maximum target speed (uniform random in range)
     minChangeTime : getURLParamIfPresent('targetMinChangeTime', 0.5),       // Minimum target direction change time (uniform random in range)
     maxChangeTime : getURLParamIfPresent('targetMaxChangeTime' , 1),        // Maximum target direction change tiem (uniform random in range)
-    offColor : getURLParamIfPresent('offTargetColor', '#00ff00'),           // Color when aim is off target (not tracked)
-    onColor : getURLParamIfPresent('onTargetColor', '#ff0000'),             // Color when aim is on target (tracked)
+    offColor : getURLParamIfPresent('offTargetColor', '#d31286'),           // Color when aim is off target (not tracked)
+    onColor : getURLParamIfPresent('onTargetColor', '#91e600'),             // Color when aim is on target (tracked)
     
     minSpawnDistance: getURLParamIfPresent('targetMinSpawnDistance', TARGET_DIST),   // Minimum target spawn distance
     maxSpawnDistance: getURLParamIfPresent('targetMaxSpawnDistance', TARGET_DIST),   // Maximum target spawn distance

--- a/js/fps.js
+++ b/js/fps.js
@@ -455,7 +455,8 @@ var config = {
     },
 
     particles : { // Particle effect configuration
-      enabled: getURLParamIfPresent('targetHitParticles', false),            // Show hit particles?
+      hitParticles: getURLParamIfPresent('targetHitParticles', false),            // Show hit particles?
+      destroyParticles: getURLParamIfPresent('targetDestroyParticles', false),    // Show destroy particles?
       size: getURLParamIfPresent('particleSize', 0.2),                     // Particle size for hitting/destroying the target
       hitCount: getURLParamIfPresent('hitParticleCount', 1),               // Particle count for hitting the target
       destroyCount: getURLParamIfPresent('destroyParticleCount', 500),     // Particle count for destroying the target
@@ -1086,12 +1087,14 @@ function damageTarget(target, hitPoint){
   // No need to do damage in this experiment
   // target.health -= config.weapon.damagePerSecond * config.weapon.firePeriod;
   if(target.health <= 0 || referenceTarget) {
-    destroyTarget(target);
+    destroyTarget(target, config.targets.particles.destroyParticles);
     clickShot = true;
     return true;
   }
   else {
-    if(config.targets.particles.enabled) makeParticles(hitPoint, target.material.color, config.targets.particles.size, config.targets.particles.hitCount, config.targets.particles.duration);
+    if(config.targets.particles.hitParticles) {
+      makeParticles(hitPoint, target.material.color, config.targets.particles.size, config.targets.particles.hitCount, config.targets.particles.duration);
+    }
     // Hit target, change color to "on"
     target.material.color = new THREE.Color(config.targets.onColor);
     return false;

--- a/js/fps.js
+++ b/js/fps.js
@@ -419,8 +419,8 @@ var config = {
     maxSize : getURLParamIfPresent('targetMaxSize', TARGET_SIZE),           // Maxmium target size (uniform random in range)
     minSpeed: getURLParamIfPresent('targetMinSpeed', 8),                    // Minimum target speed (uniform random in range)
     maxSpeed : getURLParamIfPresent('targetMaxSpeed', 12),                  // Maximum target speed (uniform random in range)
-    minChangeTime : getURLParamIfPresent('targetMinChangeTime', 0.5),      // Minimum target direction change time (uniform random in range)
-    maxChangeTime : getURLParamIfPresent('targetMaxChangeTime' , 1),     // Maximum target direction change tiem (uniform random in range)
+    minChangeTime : getURLParamIfPresent('targetMinChangeTime', 0.5),       // Minimum target direction change time (uniform random in range)
+    maxChangeTime : getURLParamIfPresent('targetMaxChangeTime' , 1),        // Maximum target direction change tiem (uniform random in range)
     offColor : getURLParamIfPresent('offTargetColor', '#00ff00'),           // Color when aim is off target (not tracked)
     onColor : getURLParamIfPresent('onTargetColor', '#ff0000'),             // Color when aim is on target (tracked)
     
@@ -446,6 +446,7 @@ var config = {
     maxJumpCrouchTime : getURLParamIfPresent('targetMaxJumpCrouchTime', 2),
 
     reference : { // Reference target configuration
+      color: getURLParamIfPresent('refTargetColor', '#ffff00'),      // Color for the reference target
       size: getURLParamIfPresent('refTargetSize', 1),             // Reference target size
       distance: getURLParamIfPresent('refTargetDistance', 30),    // Reference target distance
     },
@@ -1021,7 +1022,7 @@ function spawnTarget(reference = false){
     const position = new THREE.Vector3();
     position.copy(fpsControls.position());
     position.add(new THREE.Vector3().setFromSphericalCoords(config.targets.reference.distance, -Math.PI/2, fpsControls.getViewAzim()));
-    makeTarget(position, config.targets.reference.size, 0, new THREE.Color(1,1,0));
+    makeTarget(position, config.targets.reference.size, 0, new THREE.Color(config.targets.reference.color));
   }
   else{
     var cameraDir = camera.getWorldDirection(new THREE.Vector3());

--- a/js/fps.js
+++ b/js/fps.js
@@ -449,7 +449,7 @@ var config = {
     maxJumpCrouchTime : getURLParamIfPresent('targetMaxJumpCrouchTime', 2),
 
     reference : { // Reference target configuration
-      color: getURLParamIfPresent('refTargetColor', '#fac200'),      // Color for the reference target
+      color: getURLParamIfPresent('refTargetColor', '#ffc800'),      // Color for the reference target
       size: getURLParamIfPresent('refTargetSize', 1),             // Reference target size
       distance: getURLParamIfPresent('refTargetDistance', 30),    // Reference target distance
     },

--- a/readme.md
+++ b/readme.md
@@ -110,8 +110,8 @@ Typically JSON parameter names are _very_ similar to URL parameter names, but of
         * Min motion change time (new direction selection interval): `targetMinChangeTime` (`Number`) = `1`
         * Max motion change time (new direction selection interval): `targetMaxChangeTime` (`Number`) = `3`
     * Color (full/min health are interpolated between)
-        * Aim off target color: `offTargetColor` (`Color`) = `#00ff00`
-        * Aim on target color: `onTargetColor` (`Color`) = `#ff0000`
+        * Aim off target color: `offTargetColor` (`Color`) = `#d31286`
+        * Aim on target color: `onTargetColor` (`Color`) = `#91e600`
     * Spawn position (uniformly randomized in range)
         * Min spawn distance: `targetMinSpawnDistance` (`Number`) = `30`
         * Max spawn distance: `targetMaxSpawnDistance` (`Number`) = `30`
@@ -130,7 +130,7 @@ Typically JSON parameter names are _very_ similar to URL parameter names, but of
         * Min time between jumps/crouches: `targetMinJumpCrouchTime` (`Number`) = `1`
         * Max time between jumps/crouches: `targetMaxJumpCrouchTime` (`Number`) = `2`
     * Reference target (red target used to reset aim direction on reload/start of trial)
-        * Color: `refTargetColor` (`Color`) = `#ffff00`
+        * Color: `refTargetColor` (`Color`) = `#ffc800`
         * Size: `refTargetSize` (`Number`) = `1`
         * Distance: `refTargetDistance` (`Number`) = `30`
     * Particles (drawn on hit/destory events)

--- a/readme.md
+++ b/readme.md
@@ -134,7 +134,8 @@ Typically JSON parameter names are _very_ similar to URL parameter names, but of
         * Size: `refTargetSize` (`Number`) = `1`
         * Distance: `refTargetDistance` (`Number`) = `30`
     * Particles (drawn on hit/destory events)
-        * Enabled: `targetHitParticles` (`Boolean`): `False`
+        * Hit Particles Enabled: `targetHitParticles` (`Boolean`): `False`
+        * Destroy Particles Enabled: `targetDestroyParticles` (`Boolean`): `False`
         * Size: `particleSize` (`Number`): `0.4`
         * Count to spawn on hit: `hitParticleCount` (`Integer`) = `25`
         * Count to spawn on destroy: `destroyParticleCount` (`Integer`) = `1000`

--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,7 @@ Typically JSON parameter names are _very_ similar to URL parameter names, but of
         * Min time between jumps/crouches: `targetMinJumpCrouchTime` (`Number`) = `1`
         * Max time between jumps/crouches: `targetMaxJumpCrouchTime` (`Number`) = `2`
     * Reference target (red target used to reset aim direction on reload/start of trial)
+        * Color: `refTargetColor` (`Color`) = `#ffff00`
         * Size: `refTargetSize` (`Number`) = `1`
         * Distance: `refTargetDistance` (`Number`) = `30`
     * Particles (drawn on hit/destory events)

--- a/readme.md
+++ b/readme.md
@@ -110,8 +110,8 @@ Typically JSON parameter names are _very_ similar to URL parameter names, but of
         * Min motion change time (new direction selection interval): `targetMinChangeTime` (`Number`) = `1`
         * Max motion change time (new direction selection interval): `targetMaxChangeTime` (`Number`) = `3`
     * Color (full/min health are interpolated between)
-        * Full/max health color: `targetMaxHealthColor` (`Color`) = `#00ff00`
-        * Min/no health color: `targetMinHealthColor` (`Color`) = `#ff0000`
+        * Aim off target color: `offTargetColor` (`Color`) = `#00ff00`
+        * Aim on target color: `onTargetColor` (`Color`) = `#ff0000`
     * Spawn position (uniformly randomized in range)
         * Min spawn distance: `targetMinSpawnDistance` (`Number`) = `30`
         * Max spawn distance: `targetMaxSpawnDistance` (`Number`) = `30`
@@ -133,6 +133,7 @@ Typically JSON parameter names are _very_ similar to URL parameter names, but of
         * Size: `refTargetSize` (`Number`) = `1`
         * Distance: `refTargetDistance` (`Number`) = `30`
     * Particles (drawn on hit/destory events)
+        * Enabled: `targetHitParticles` (`Boolean`): `False`
         * Size: `particleSize` (`Number`): `0.4`
         * Count to spawn on hit: `hitParticleCount` (`Integer`) = `25`
         * Count to spawn on destroy: `destroyParticleCount` (`Integer`) = `1000`


### PR DESCRIPTION
This branch removes use of particles as it was causing higher levels of performance (frame time) variation in many systems. Instead it uses an `onTargetColor` and `offTargetColor` (URL parametrizable) to set a color for the target when (un)tracked. Hopefully this improves performance and simplifies the experience.

This branch also adds support for a `refTargetColor` URL parameter to allow control of the reference target color (w/o actually changing defaults).