### PR TITLE
Adjust Target Motion to Improve Reproducibility

### DIFF
--- a/js/fps.js
+++ b/js/fps.js
@@ -28,9 +28,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 const TARGET_SIZE = 0.6;
 const TARGET_DIST = 30;
 const TARGET_HEIGHT = 6;
+
+const TARGET_JUMP = false;
+const TARGET_CROUCH = false;
 const TARGET_CROUCH_HEIGHT = 4;
-const TARGET_JUMP = true;
-const TARGET_CROUCH = true;
 
 // States that the experiment progresses through
 const states = ["sensitivity", "latency", "measurement"]
@@ -419,8 +420,8 @@ var config = {
     maxSize : getURLParamIfPresent('targetMaxSize', TARGET_SIZE),                         // Maxmium target size (uniform random in range)
     minSpeed: getURLParamIfPresent('targetMinSpeed', 8),                        // Minimum target speed (uniform random in range)
     maxSpeed : getURLParamIfPresent('targetMaxSpeed', 12),                      // Maximum target speed (uniform random in range)
-    minChangeTime : getURLParamIfPresent('targetMinChangeTime', 0.5),             // Minimum target direction change time (uniform random in range)
-    maxChangeTime : getURLParamIfPresent('targetMaxChangeTime' , 1),            // Maximum target direction change tiem (uniform random in range)
+    minChangeTime : getURLParamIfPresent('targetMinChangeTime', 0.25),             // Minimum target direction change time (uniform random in range)
+    maxChangeTime : getURLParamIfPresent('targetMaxChangeTime' , 0.5),            // Maximum target direction change tiem (uniform random in range)
     fullHealthColor : getURLParamIfPresent('targetMaxHealthColor', '#00ff00'),  // Color for full health target
     minHealthColor : getURLParamIfPresent('targetMinHealthColor', '#ff0000'),   // Color for min health 
     

--- a/readme.md
+++ b/readme.md
@@ -105,10 +105,10 @@ Typically JSON parameter names are _very_ similar to URL parameter names, but of
     * Min size (uniform random in range): `targetMinSize` (`Number`) = `0.6`
     * Max size (uniform random in range): `targetMaxSize` (`Number`) = `0.6`
     * Movement parameters (uniformly randomized in range)
-        * Min speed (along a line): `targetMinSpeed` (`Number`) = `5`
-        * Max speed (along a line): `targetMaxSpeed` (`Number`) = `15`
-        * Min motion change time (new direction selection interval): `targetMinChangeTime` (`Number`) = `1`
-        * Max motion change time (new direction selection interval): `targetMaxChangeTime` (`Number`) = `3`
+        * Min speed (along a line): `targetMinSpeed` (`Number`) = `8`
+        * Max speed (along a line): `targetMaxSpeed` (`Number`) = `12`
+        * Min motion change time (new direction selection interval): `targetMinChangeTime` (`Number`) = `0.25`
+        * Max motion change time (new direction selection interval): `targetMaxChangeTime` (`Number`) = `0.5`
     * Color (full/min health are interpolated between)
         * Full/max health color: `targetMaxHealthColor` (`Color`) = `#00ff00`
         * Min/no health color: `targetMinHealthColor` (`Color`) = `#ff0000`
@@ -122,8 +122,8 @@ Typically JSON parameter names are _very_ similar to URL parameter names, but of
             * Min elevation spawn angle: `targetSpawnMinElev` (`Number` degrees) = `3` -->
     * Target height above ground: `targetHeight` (`Number`) = 6
     * Target jumps
-        * Can target jump?: `targetJump` (`Boolean`) = `True`
-        * Can target crouch?: `targetCrouch` (`Boolean`) = `True`
+        * Can target jump?: `targetJump` (`Boolean`) = `False`
+        * Can target crouch?: `targetCrouch` (`Boolean`) = `False`
         * Crouch height: `targetCrouchHeight` (`Number`) = `4`
         * Jump speed: `targetJumpSpeed` (`Number`) = `20`
         * Jump gravity: `targetJumpGravity` (`Number`) = `65`


### PR DESCRIPTION
This branch reduces the target motion change period range from 0.5-1s to 0.25-0.5s and disables crouching/jumping in the experiment.

The idea here is that (previously) there was a non-negligible chance (~1/10) that a target would continue moving in a relatively constant direction for 2-3s at several points in a trial. This along with the random jumps/crouches resulted in subject complaints that the experiment was too hard/easy in various windows.

By removing the jump/crouch and instead focusing on effectively doubling the anticipated number of horizontal direction changes in the experiment we hopefully see similar/larger effects of latency and reduce some of condition-to-condition noise we may have been seeing as a result of more varied random target motion.