### PR TITLE
Target acceleration

### DIFF
--- a/js/fps.js
+++ b/js/fps.js
@@ -430,7 +430,7 @@ var config = {
     maxSpeed : getURLParamIfPresent('targetMaxSpeed', 8),                  // Maximum target speed (uniform random in range)
     minChangeTime : getURLParamIfPresent('targetMinChangeTime', 0.25),      // Minimum target direction change time (uniform random in range)
     maxChangeTime : getURLParamIfPresent('targetMaxChangeTime' , 0.5),      // Maximum target direction change tiem (uniform random in range)
-    changeAccel: getURLParamIfPresent('targetChangeAccel', 100000),         // Acceleration to apply to target velocity changes
+    changeAccel: getURLParamIfPresent('targetChangeAccel', 50),             // Acceleration to apply to target velocity changes
     offColor : getURLParamIfPresent('offTargetColor', '#d31286'),           // Color when aim is off target (not tracked)
     onColor : getURLParamIfPresent('onTargetColor', '#91e600'),             // Color when aim is on target (tracked)
     

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,7 @@ Typically JSON parameter names are _very_ similar to URL parameter names, but of
         * Max speed (along a line): `targetMaxSpeed` (`Number`) = `12`
         * Min motion change time (new direction selection interval): `targetMinChangeTime` (`Number`) = `0.25`
         * Max motion change time (new direction selection interval): `targetMaxChangeTime` (`Number`) = `0.5`
+        * Motion change acceleration: `targetChangeAccel` (`Number`) = `100000`
     * Color (full/min health are interpolated between)
         * Aim off target color: `offTargetColor` (`Color`) = `#d31286`
         * Aim on target color: `onTargetColor` (`Color`) = `#91e600`

--- a/readme.md
+++ b/readme.md
@@ -109,7 +109,7 @@ Typically JSON parameter names are _very_ similar to URL parameter names, but of
         * Max speed (along a line): `targetMaxSpeed` (`Number`) = `12`
         * Min motion change time (new direction selection interval): `targetMinChangeTime` (`Number`) = `0.25`
         * Max motion change time (new direction selection interval): `targetMaxChangeTime` (`Number`) = `0.5`
-        * Motion change acceleration: `targetChangeAccel` (`Number`) = `100000`
+        * Motion change acceleration: `targetChangeAccel` (`Number`) = `50`
     * Color (full/min health are interpolated between)
         * Aim off target color: `offTargetColor` (`Color`) = `#d31286`
         * Aim on target color: `onTargetColor` (`Color`) = `#91e600`

--- a/readme.md
+++ b/readme.md
@@ -105,8 +105,8 @@ Typically JSON parameter names are _very_ similar to URL parameter names, but of
     * Min size (uniform random in range): `targetMinSize` (`Number`) = `0.6`
     * Max size (uniform random in range): `targetMaxSize` (`Number`) = `0.6`
     * Movement parameters (uniformly randomized in range)
-        * Min speed (along a line): `targetMinSpeed` (`Number`) = `8`
-        * Max speed (along a line): `targetMaxSpeed` (`Number`) = `12`
+        * Min speed (along a line): `targetMinSpeed` (`Number`) = `6`
+        * Max speed (along a line): `targetMaxSpeed` (`Number`) = `8`
         * Min motion change time (new direction selection interval): `targetMinChangeTime` (`Number`) = `0.25`
         * Max motion change time (new direction selection interval): `targetMaxChangeTime` (`Number`) = `0.5`
         * Motion change acceleration: `targetChangeAccel` (`Number`) = `50`


### PR DESCRIPTION
This branch adds support for a linear acceleration of targets via a `targetChangeAccel` URL parameter. Experiment designers need to be careful when using this parameter as setting the motion change period low/target velocity sufficiently high can result in certain target accelerations meaning the target does not reach its desired velocity before changing. This can produce some odd behavior as the `lerp()` target changes suddenly.